### PR TITLE
Cache SwiftSoup queries for notes, remove async

### DIFF
--- a/FAKit/Sources/FAKit/OnlineFASession.swift
+++ b/FAKit/Sources/FAKit/OnlineFASession.swift
@@ -159,7 +159,7 @@ public class OnlineFASession: FASession {
     // MARK: - Notes
     public func notePreviews(from box: NotesBox) async -> [FANotePreview] {
         guard let data = await dataSource.httpData(from: box.url, cookies: cookies),
-              let page = await FANotesPage(data: data)
+              let page = FANotesPage(data: data)
         else { return [] }
         
         let headers = page.noteHeaders
@@ -215,7 +215,7 @@ public class OnlineFASession: FASession {
             throw Error.FAErrorResponse(errorPage.message)
         }
         
-        guard await FANotesPage(data: data) != nil else {
+        guard FANotesPage(data: data) != nil else {
             logger.error("Failed sending note")
             throw Error.requestFailure
         }

--- a/FAKit/Tests/FAPagesTests/FANotesPageTests.swift
+++ b/FAKit/Tests/FAPagesTests/FANotesPageTests.swift
@@ -11,14 +11,14 @@ import XCTest
 final class FANotesPageTests: XCTestCase {
     func testEmptyInbox_returnsNoNote() async throws {
         let data = testData("www.furaffinity.net:msg:pms-empty.html")
-        let page = await FANotesPage(data: data)
+        let page = FANotesPage(data: data)
         XCTAssertNotNil(page)
         XCTAssertEqual([], page!.noteHeaders)
     }
     
     func testMessagesInInbox_returnsNotes() async throws {
         let data = testData("www.furaffinity.net:msg:pms-unread.html")
-        let page = await FANotesPage(data: data)
+        let page = FANotesPage(data: data)
         XCTAssertNotNil(page)
         
         let expected: [FANotesPage.NoteHeader] = [


### PR DESCRIPTION
In preparation of upcoming SwiftSoup changes, this converts the `FANotesPage` to non-asynchronous processing but speeds up the processing by caching the parsed queries.

Once the next SwiftSoup version is out this can be further improved:

* `@preconcurrency` for the `import SwiftSoup` can be removed since the `Evaluator` instances are going to be sendable.
* The `CssSelector.select(eval, node)` can be changed to `node.select(eval)` which is nicer to read.
* `try elementsSelect(Self.titleQuery, baseNode.array())` can be replaced by `baseNode.select(Self.titleQuery)` and the helper function can be deleted.

We could also wait for the next SwiftSoup version before merging this merge request and do the improvements mentioned above. I've created this merge request mostly as a demonstration so it doesn't get lost.